### PR TITLE
add support for << meta-character

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ENV_SRC = env.c env_utils.c
 HISTORY_SRC = history.c
 LEXING_SRC = lexing.c lexing_utils.c expand.c token.c id_token.c
 BUILTINS_SRC = cd.c builtins_utils.c
-PARSING_SRC = parsing.c exec_node.c
+PARSING_SRC = parsing.c exec_node.c heredoc.c
 
 ENV_SRC_DIR = env/
 HISTORY_SRC_DIR = history/

--- a/inc/data_structures.h
+++ b/inc/data_structures.h
@@ -54,6 +54,7 @@ typedef struct s_exec_node
 	char				**cmd;
 	char				*(filename[2]); // each can be NULL or a filename
 	int					io[2]; // both can be either 0, 1, 2, or 3 (for file)
+	int					oflags[2];
 }						t_exec_node;
 
 /* storing env as a linked list is simplifies the implementation

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -16,6 +16,10 @@
 #  define HIST_FILE ".zzsh_history"
 # endif
 
+# ifndef HERE_DOC_LEN
+#  define HERE_DOC_LEN 8
+# endif
+
 t_env_lst		*create_environment(t_env_lst **env_lst, char *envp[]);
 t_env_lst		*create_env_lst(char name[]);
 size_t			ft_strlen_c(char str[], char c);
@@ -80,4 +84,7 @@ t_exec_node		*create_exec_node(void);
 t_list			*parse_tokens(t_list *tokens);
 void			print_exec(t_list	*exec_lst);
 
+/* here_doc.c */
+
+int				here_doc(char *delimiter);
 #endif

--- a/src/lexing/id_token.c
+++ b/src/lexing/id_token.c
@@ -11,6 +11,8 @@ t_bool	determine_redirect(char token_str[])
 		return (TRUE);
 	else if (ft_strncmp(token_str, ">>", 3) == 0)
 		return (TRUE);
+	else if (ft_strncmp(token_str, "<<", 3) == 0)
+		return (TRUE);
 	return (FALSE);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -52,11 +52,6 @@ int	main(int argc, char *argv[], char *envp[])
 	int			exit_status;
 
 	env_lst = create_environment(&env_lst, envp);
-	if (argc == 3 && !ft_strncmp(argv[1], "-c", 3))
-	{
-		interpret_line(argv[2], env_lst);
-		exit(EXIT_SUCCESS);
-	}
 	exit_status = readline_loop(env_lst);
 	destroy_env_lst(env_lst);
 	return (exit_status);

--- a/src/parsing/heredoc.c
+++ b/src/parsing/heredoc.c
@@ -6,12 +6,13 @@ int	here_doc(char *delimiter)
 	char	*line;
 	int		hd_fd;
 
-	filename = create_random_str(HERE_DOC_LEN);
+	filename = ft_concat(2, "tmp_", create_random_str(HERE_DOC_LEN));
 	if (!filename)
 		exit(EXIT_FAILURE);
 	hd_fd = open(filename, O_CREAT | O_WRONLY, 0644);
 	if (hd_fd < 0)
 		exit(EXIT_FAILURE);
+	unlink(filename);
 	line = NULL;
 	write(1, "here_doc_ish", ft_strlen("here_doc_ish"));
 	line = get_next_line(STDIN_FILENO);

--- a/src/parsing/heredoc.c
+++ b/src/parsing/heredoc.c
@@ -1,0 +1,26 @@
+#include "minishell.h"
+
+int	here_doc(char *delimiter)
+{
+	char	*filename;
+	char	*line;
+	int		hd_fd;
+
+	filename = create_random_str(HERE_DOC_LEN);
+	if (!filename)
+		exit(EXIT_FAILURE);
+	hd_fd = open(filename, O_CREAT | O_WRONLY, 0644);
+	if (hd_fd < 0)
+		exit(EXIT_FAILURE);
+	line = NULL;
+	write(1, "here_doc_ish", ft_strlen("here_doc_ish"));
+	line = get_next_line(STDIN_FILENO);
+	while (line && strncmp(line, delimiter, ft_strlen(delimiter)))
+	{
+		write(1, "here_doc_ish> ", ft_strlen("here_doc_ish> "));
+		write(hd_fd, line, ft_strlen(line));
+		free(line);
+		line = get_next_line(STDIN_FILENO);
+	}
+	return (hd_fd);
+}


### PR DESCRIPTION
Subject : "<< should be given a delimiter, then read the input until a line containing the
delimiter is seen. However, it doesn’t have to update the history!"

remove test for "exit" command